### PR TITLE
README for CountingBloomFilter: insert() -> add()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Similarly, the counting Bloom filter can be used as well.
 >>> from cuckoofilter import CountingBloomFilter
 >>> b_filter = CountingBloomFilter(10000)
 
->>> b_filter.insert('James')
+>>> b_filter.add('James')
 >>> print("James in c_filter == {}".format("James" in c_filter))
 James in b_filter == True
 


### PR DESCRIPTION
@adebayoj quick typo, example in the README for CountingBloomFilter generates an error at `b_filter.insert( )` which should be `b_filter.add( )`